### PR TITLE
Modified build script to automatically add ide args

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ minecraft {
     // Use non-default mappings at your own risk. they may not allways work.
     // simply re-run your setup task after changing the mappings to update your workspace.
     mappings = "snapshot_20160518"
+	coreMod = "ValkyrienWarfareBase.CoreMod.ValkyrienWarfarePlugin"
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 }
 
@@ -101,8 +102,7 @@ processResources
 jar {
     manifest {
 		attributes 'FMLAT': 'ValkyrienWarfare_At.cfg'
-		attributes 'FMLCorePlugin': 'ValkyrienWarfareBase.CoreMod.ValkyrienWarfarePlugin' 
-		attributes 'FMLCorePluginContainsFMLMod': 'false'
+		attributes 'FMLCorePluginContainsFMLMod': 'true'
     }
 }
 
@@ -112,7 +112,7 @@ task deobfJar(type: Jar) {
 	manifest {
 		attributes 'FMLAT': 'ValkyrienWarfare_At.cfg'
 		attributes 'FMLCorePlugin': 'ValkyrienWarfareBase.CoreMod.ValkyrienWarfarePlugin' 
-		attributes 'FMLCorePluginContainsFMLMod': 'false'
+		attributes 'FMLCorePluginContainsFMLMod': 'true'
     }
 }
 


### PR DESCRIPTION
By using `minecraft.coreMod`, forge gradle plugin will automatically add
`Dfml` coremod args to IDE and manifest information.

Also, if we want out mods to be read, `containsMod` flags should probably be
true. But i think that these are ignored now. Have to check.