### PR TITLE
De-ASM-ification - RenderManager#doRenderEntity

### DIFF
--- a/src/main/java/ValkyrienWarfareBase/Client/RenderManagerOverride.java
+++ b/src/main/java/ValkyrienWarfareBase/Client/RenderManagerOverride.java
@@ -28,6 +28,15 @@ public class RenderManagerOverride extends RenderManager {
 	 * INTERCEPT
 	 */
 
+	public boolean shouldRender(Entity entityIn, ICamera camera, double camX, double camY, double camZ){
+		return !ValkyrienWarfareMod.physicsManager.isEntityFixed(entityIn) && def.shouldRender(entityIn, camera, camX, camY, camZ);
+	}
+
+	public void renderEntityStatic(Entity p_188388_1_, float p_188388_2_, boolean p_188388_3_){
+		if(!ValkyrienWarfareMod.physicsManager.isEntityFixed(p_188388_1_))
+			def.renderEntityStatic(p_188388_1_, p_188388_2_, p_188388_3_);
+	}
+
 	public void doRenderEntity(Entity entityIn, double x, double y, double z, float yaw, float partialTicks, boolean p_188391_10_){
 		if(!ValkyrienWarfareMod.physicsManager.isEntityFixed(entityIn))
 			def.doRenderEntity(entityIn, x, y, z, yaw, partialTicks, p_188391_10_);
@@ -80,14 +89,6 @@ public class RenderManagerOverride extends RenderManager {
 
 	public boolean isRenderMultipass(Entity p_188390_1_){
 		return def.isRenderMultipass(p_188390_1_);
-	}
-
-	public boolean shouldRender(Entity entityIn, ICamera camera, double camX, double camY, double camZ){
-		return def.shouldRender(entityIn, camera, camX, camY, camZ);
-	}
-
-	public void renderEntityStatic(Entity p_188388_1_, float p_188388_2_, boolean p_188388_3_){
-		def.renderEntityStatic(p_188388_1_, p_188388_2_, p_188388_3_);
 	}
 
 	public void renderMultipass(Entity p_188389_1_, float p_188389_2_){

--- a/src/main/java/ValkyrienWarfareBase/Client/RenderManagerOverride.java
+++ b/src/main/java/ValkyrienWarfareBase/Client/RenderManagerOverride.java
@@ -1,0 +1,109 @@
+package ValkyrienWarfareBase.Client;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.renderer.culling.ICamera;
+import net.minecraft.client.renderer.entity.Render;
+import net.minecraft.client.renderer.entity.RenderManager;
+import net.minecraft.client.renderer.entity.RenderPlayer;
+import net.minecraft.client.settings.GameSettings;
+import net.minecraft.entity.Entity;
+import net.minecraft.world.World;
+
+public class RenderManagerOverride extends RenderManager {
+
+	private final RenderManager def;
+
+	public RenderManagerOverride(RenderManager def){
+		super(def.renderEngine, Minecraft.getMinecraft().getRenderItem());
+		this.def = def;
+	}
+
+	public Map<String, RenderPlayer> getSkinMap(){
+		return def.getSkinMap();
+	}
+
+	public void setRenderPosition(double renderPosXIn, double renderPosYIn, double renderPosZIn){
+		def.setRenderPosition(renderPosXIn, renderPosYIn, renderPosZIn);
+	}
+
+	public <T extends Entity> Render<T> getEntityClassRenderObject(Class<? extends Entity> entityClass){
+		return def.getEntityClassRenderObject(entityClass);
+	}
+
+	@Nullable
+	public <T extends Entity> Render<T> getEntityRenderObject(T entityIn){
+		return def.getEntityRenderObject(entityIn);
+	}
+
+	public void cacheActiveRenderInfo(World worldIn, FontRenderer textRendererIn, Entity livingPlayerIn, Entity pointedEntityIn, GameSettings optionsIn, float partialTicks){
+		def.cacheActiveRenderInfo(worldIn, textRendererIn, livingPlayerIn, pointedEntityIn, optionsIn, partialTicks);
+	}
+
+	public void setPlayerViewY(float playerViewYIn){
+		def.setPlayerViewY(playerViewYIn);
+	}
+
+	public boolean isRenderShadow(){
+		return def.isRenderShadow();
+	}
+
+	public void setRenderShadow(boolean renderShadowIn){
+		def.setRenderShadow(renderShadowIn);
+	}
+
+	public void setDebugBoundingBox(boolean debugBoundingBoxIn){
+		def.setDebugBoundingBox(debugBoundingBoxIn);
+	}
+
+	public boolean isDebugBoundingBox(){
+		return def.isDebugBoundingBox();
+	}
+
+	public boolean isRenderMultipass(Entity p_188390_1_){
+		return def.isRenderMultipass(p_188390_1_);
+	}
+
+	public boolean shouldRender(Entity entityIn, ICamera camera, double camX, double camY, double camZ){
+		return def.shouldRender(entityIn, camera, camX, camY, camZ);
+	}
+
+	public void renderEntityStatic(Entity p_188388_1_, float p_188388_2_, boolean p_188388_3_){
+		def.renderEntityStatic(p_188388_1_, p_188388_2_, p_188388_3_);
+	}
+
+	public void doRenderEntity(Entity entityIn, double x, double y, double z, float yaw, float partialTicks, boolean p_188391_10_){
+		def.doRenderEntity(entityIn, x, y, z, yaw, partialTicks, p_188391_10_);
+	}
+
+	public void renderMultipass(Entity p_188389_1_, float p_188389_2_){
+		def.renderMultipass(p_188389_1_, p_188389_2_);
+	}
+
+	/**
+	 * World sets this RenderManager's worldObj to the world provided
+	 */
+	public void set(@Nullable World worldIn){
+		def.set(worldIn);
+	}
+
+	public double getDistanceToCamera(double x, double y, double z){
+		return def.getDistanceToCamera(x, y, z);
+	}
+
+	/**
+	 * Returns the font renderer
+	 */
+	public FontRenderer getFontRenderer(){
+		return def.getFontRenderer();
+	}
+
+	public void setRenderOutlines(boolean renderOutlinesIn){
+		def.setRenderOutlines(renderOutlinesIn);
+	}
+
+}

--- a/src/main/java/ValkyrienWarfareBase/Client/RenderManagerOverride.java
+++ b/src/main/java/ValkyrienWarfareBase/Client/RenderManagerOverride.java
@@ -5,6 +5,8 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 import ValkyrienWarfareBase.ValkyrienWarfareMod;
+import ValkyrienWarfareBase.Render.PhysObjectRender;
+import ValkyrienWarfareBase.Render.PhysObjectRenderManager;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.culling.ICamera;
@@ -28,17 +30,21 @@ public class RenderManagerOverride extends RenderManager {
 	 * INTERCEPT
 	 */
 
+	private boolean shouldRender(Entity entity){
+		return PhysObjectRenderManager.renderingMountedEntities || !ValkyrienWarfareMod.physicsManager.isEntityFixed(entity);
+	}
+
 	public boolean shouldRender(Entity entityIn, ICamera camera, double camX, double camY, double camZ){
-		return !ValkyrienWarfareMod.physicsManager.isEntityFixed(entityIn) && def.shouldRender(entityIn, camera, camX, camY, camZ);
+		return shouldRender(entityIn) && def.shouldRender(entityIn, camera, camX, camY, camZ);
 	}
 
 	public void renderEntityStatic(Entity p_188388_1_, float p_188388_2_, boolean p_188388_3_){
-		if(!ValkyrienWarfareMod.physicsManager.isEntityFixed(p_188388_1_))
+		if(shouldRender(p_188388_1_))
 			def.renderEntityStatic(p_188388_1_, p_188388_2_, p_188388_3_);
 	}
 
 	public void doRenderEntity(Entity entityIn, double x, double y, double z, float yaw, float partialTicks, boolean p_188391_10_){
-		if(!ValkyrienWarfareMod.physicsManager.isEntityFixed(entityIn))
+		if(shouldRender(entityIn))
 			def.doRenderEntity(entityIn, x, y, z, yaw, partialTicks, p_188391_10_);
 	}
 

--- a/src/main/java/ValkyrienWarfareBase/Client/RenderManagerOverride.java
+++ b/src/main/java/ValkyrienWarfareBase/Client/RenderManagerOverride.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import ValkyrienWarfareBase.ValkyrienWarfareMod;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.culling.ICamera;
@@ -22,6 +23,19 @@ public class RenderManagerOverride extends RenderManager {
 		super(def.renderEngine, Minecraft.getMinecraft().getRenderItem());
 		this.def = def;
 	}
+
+	/*
+	 * INTERCEPT
+	 */
+
+	public void doRenderEntity(Entity entityIn, double x, double y, double z, float yaw, float partialTicks, boolean p_188391_10_){
+		if(!ValkyrienWarfareMod.physicsManager.isEntityFixed(entityIn))
+			def.doRenderEntity(entityIn, x, y, z, yaw, partialTicks, p_188391_10_);
+	}
+
+	/*
+	 * We don't care
+	 */
 
 	public Map<String, RenderPlayer> getSkinMap(){
 		return def.getSkinMap();
@@ -74,10 +88,6 @@ public class RenderManagerOverride extends RenderManager {
 
 	public void renderEntityStatic(Entity p_188388_1_, float p_188388_2_, boolean p_188388_3_){
 		def.renderEntityStatic(p_188388_1_, p_188388_2_, p_188388_3_);
-	}
-
-	public void doRenderEntity(Entity entityIn, double x, double y, double z, float yaw, float partialTicks, boolean p_188391_10_){
-		def.doRenderEntity(entityIn, x, y, z, yaw, partialTicks, p_188391_10_);
 	}
 
 	public void renderMultipass(Entity p_188389_1_, float p_188389_2_){

--- a/src/main/java/ValkyrienWarfareBase/CoreMod/CallRunnerClient.java
+++ b/src/main/java/ValkyrienWarfareBase/CoreMod/CallRunnerClient.java
@@ -465,12 +465,6 @@ public class CallRunnerClient extends CallRunner {
 		renderGlobal.renderEntities(renderViewEntity, camera, partialTicks);
 	}
 
-	public static void onDoRenderEntity(RenderManager manager, Entity entityIn, double x, double y, double z, float yaw, float partialTicks, boolean p_188391_10_){
-		if(!ValkyrienWarfareMod.physicsManager.isEntityFixed(entityIn)){
-			manager.doRenderEntity(entityIn, x, y, z, yaw, partialTicks, p_188391_10_);
-		}
-    }
-
 	public static boolean onInvalidateRegionAndSetBlock(WorldClient client, BlockPos pos, IBlockState state) {
 		int i = pos.getX();
 		int j = pos.getY();

--- a/src/main/java/ValkyrienWarfareBase/CoreMod/TransformAdapter.java
+++ b/src/main/java/ValkyrienWarfareBase/CoreMod/TransformAdapter.java
@@ -49,7 +49,6 @@ public class TransformAdapter extends ClassVisitor {
 	private static final String ViewFrustumName = "net/minecraft/client/renderer/ViewFrustum";
 	private static final String EntityRendererName = "net/minecraft/client/renderer/EntityRenderer";
 	private static final String FrustumName = "net/minecraft/client/renderer/culling/Frustum";
-	private static final String RenderManagerName = "net/minecraft/client/renderer/entity/RenderManager";
 
 	private static final String IteratorName = "java/util/Iterator";
 	private static final String PredicateName = "com/google/common/base/Predicate";
@@ -74,11 +73,6 @@ public class TransformAdapter extends ClassVisitor {
 		
 		if (isMethod(calledDesc, "(DF)L" + RayTraceResultName + ";", calledName, EntityClassName, "rayTrace", "func_174822_a", calledOwner)) {
 			mv.visitMethodInsn(Opcodes.INVOKESTATIC, ValkyrienWarfarePlugin.PathClient, "onRayTrace", String.format("(L%s;DF)L"+RayTraceResultName+";", EntityClassName));
-			return false;
-		}
-		
-		if (isMethod(calledDesc, "(L"+EntityClassName+";DDDFFZ)V", calledName, RenderManagerName, "doRenderEntity", "func_188391_a", calledOwner)) {
-			mv.visitMethodInsn(Opcodes.INVOKESTATIC, ValkyrienWarfarePlugin.PathClient, "onDoRenderEntity", String.format("(L%s;L"+EntityClassName+";DDDFFZ)V", RenderManagerName));
 			return false;
 		}
 		

--- a/src/main/java/ValkyrienWarfareBase/Proxy/ClientProxy.java
+++ b/src/main/java/ValkyrienWarfareBase/Proxy/ClientProxy.java
@@ -4,13 +4,16 @@ import ValkyrienWarfareBase.EventsClient;
 import ValkyrienWarfareBase.KeyHandler;
 import ValkyrienWarfareBase.ValkyrienWarfareMod;
 import ValkyrienWarfareBase.API.Vector;
+import ValkyrienWarfareBase.Client.RenderManagerOverride;
 import ValkyrienWarfareBase.Math.Quaternion;
 import ValkyrienWarfareBase.PhysicsManagement.PhysicsWrapperEntity;
 import ValkyrienWarfareBase.Render.PhysObjectRenderFactory;
+import code.elix_x.excomms.reflection.ReflectionHelper.AClass;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.client.renderer.culling.ICamera;
+import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.item.Item;
 import net.minecraftforge.client.model.obj.OBJLoader;
 import net.minecraftforge.common.MinecraftForge;
@@ -43,6 +46,7 @@ public class ClientProxy extends CommonProxy {
 	@Override
 	public void postInit(FMLPostInitializationEvent e) {
 		super.postInit(e);
+		new AClass<>(Minecraft.class).<RenderManager>getDeclaredField("renderManager").setAccessible(true).set(Minecraft.getMinecraft(), new RenderManagerOverride(Minecraft.getMinecraft().getRenderManager()));
 	}
 
 	private void registerBlockItem(Block toRegister) {

--- a/src/main/java/ValkyrienWarfareBase/Proxy/ClientProxy.java
+++ b/src/main/java/ValkyrienWarfareBase/Proxy/ClientProxy.java
@@ -11,6 +11,8 @@ import ValkyrienWarfareBase.Render.PhysObjectRenderFactory;
 import code.elix_x.excomms.reflection.ReflectionHelper.AClass;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.ItemRenderer;
+import net.minecraft.client.renderer.RenderGlobal;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.client.renderer.culling.ICamera;
 import net.minecraft.client.renderer.entity.RenderManager;
@@ -47,6 +49,8 @@ public class ClientProxy extends CommonProxy {
 	public void postInit(FMLPostInitializationEvent e) {
 		super.postInit(e);
 		new AClass<>(Minecraft.class).<RenderManager>getDeclaredField("renderManager").setAccessible(true).set(Minecraft.getMinecraft(), new RenderManagerOverride(Minecraft.getMinecraft().getRenderManager()));
+		new AClass<>(ItemRenderer.class).<RenderManager>getDeclaredField("renderManager").setAccessible(true).setFinal(false).set(Minecraft.getMinecraft().getItemRenderer(), Minecraft.getMinecraft().getRenderManager());
+		new AClass<>(RenderGlobal.class).<RenderManager>getDeclaredField("renderManager").setFinal(false).set(Minecraft.getMinecraft().renderGlobal, Minecraft.getMinecraft().getRenderManager());
 	}
 
 	private void registerBlockItem(Block toRegister) {

--- a/src/main/java/ValkyrienWarfareBase/Proxy/ClientProxy.java
+++ b/src/main/java/ValkyrienWarfareBase/Proxy/ClientProxy.java
@@ -48,9 +48,9 @@ public class ClientProxy extends CommonProxy {
 	@Override
 	public void postInit(FMLPostInitializationEvent e) {
 		super.postInit(e);
-		new AClass<>(Minecraft.class).<RenderManager>getDeclaredField("renderManager").setAccessible(true).set(Minecraft.getMinecraft(), new RenderManagerOverride(Minecraft.getMinecraft().getRenderManager()));
-		new AClass<>(ItemRenderer.class).<RenderManager>getDeclaredField("renderManager").setAccessible(true).setFinal(false).set(Minecraft.getMinecraft().getItemRenderer(), Minecraft.getMinecraft().getRenderManager());
-		new AClass<>(RenderGlobal.class).<RenderManager>getDeclaredField("renderManager").setFinal(false).set(Minecraft.getMinecraft().renderGlobal, Minecraft.getMinecraft().getRenderManager());
+		new AClass<>(Minecraft.class).<RenderManager>getDeclaredField("renderManager", "field_175616_W").setAccessible(true).set(Minecraft.getMinecraft(), new RenderManagerOverride(Minecraft.getMinecraft().getRenderManager()));
+		new AClass<>(ItemRenderer.class).<RenderManager>getDeclaredField("renderManager", "field_178111_g").setAccessible(true).setFinal(false).set(Minecraft.getMinecraft().getItemRenderer(), Minecraft.getMinecraft().getRenderManager());
+		new AClass<>(RenderGlobal.class).<RenderManager>getDeclaredField("renderManager", "field_175010_j").setFinal(false).set(Minecraft.getMinecraft().renderGlobal, Minecraft.getMinecraft().getRenderManager());
 	}
 
 	private void registerBlockItem(Block toRegister) {

--- a/src/main/java/ValkyrienWarfareBase/Render/PhysObjectRenderManager.java
+++ b/src/main/java/ValkyrienWarfareBase/Render/PhysObjectRenderManager.java
@@ -39,6 +39,8 @@ import net.minecraftforge.client.ForgeHooksClient;
  */
 public class PhysObjectRenderManager {
 
+	public static boolean renderingMountedEntities = false;
+
 	public boolean needsSolidUpdate = true, needsCutoutUpdate = true, needsCutoutMippedUpdate = true, needsTranslucentUpdate = true;
 	public int glCallListSolid = -1;
 	public int glCallListTranslucent = -1;
@@ -209,6 +211,8 @@ public class PhysObjectRenderManager {
 	}
 
 	public void renderEntities(float partialTicks) {
+		renderingMountedEntities = true;
+
 		ArrayList<FixedEntityData> fixedEntities = new ArrayList();// ArrayList<FixedEntityData>) parent.fixedEntities.clone();
 		List<Entity> mountedEntities = parent.wrapper.riddenByEntities;
 		
@@ -267,6 +271,8 @@ public class PhysObjectRenderManager {
 			
 			}
 		}
+
+		renderingMountedEntities = false;
 	}
 
 	public boolean shouldRender() {

--- a/src/main/java/code/elix_x/excomms/reflection/ReflectionHelper.java
+++ b/src/main/java/code/elix_x/excomms/reflection/ReflectionHelper.java
@@ -1,0 +1,420 @@
+package code.elix_x.excomms.reflection;
+
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import com.google.common.collect.Lists;
+
+@SuppressWarnings("unchecked")
+public class ReflectionHelper {
+
+	private static final Field fieldConstructorModifiers;
+	private static final Field fieldFieldModifiers;
+	private static final Field fieldMethodModifiers;
+
+	static{
+		try{
+			fieldConstructorModifiers = Constructor.class.getDeclaredField("modifiers");
+			fieldConstructorModifiers.setAccessible(true);
+			fieldFieldModifiers = Field.class.getDeclaredField("modifiers");
+			fieldFieldModifiers.setAccessible(true);
+			fieldMethodModifiers = Method.class.getDeclaredField("modifiers");
+			fieldMethodModifiers.setAccessible(true);
+		} catch(Exception e){
+			throw new RuntimeException(e);
+		}
+	}
+
+	public static Field findField(Class<?> claz, String... names){
+		Exception e = null;
+		Class<?> clas = claz;
+		while(claz != null){
+			for(String name : names){
+				try{
+					return clas.getDeclaredField(name);
+				} catch(Exception ee){
+					e = ee;
+				}
+			}
+			clas = claz.getSuperclass();
+		}
+		throw new IllegalArgumentException(e);
+	}
+
+	public static Method findMethod(Class<?> claz, String[] names, Class<?>... args){
+		Exception e = null;
+		Class<?> clas = claz;
+		while(claz != null){
+			for(String name : names){
+				try{
+					return clas.getDeclaredMethod(name, args);
+				} catch(Exception ee){
+					e = ee;
+				}
+			}
+			clas = claz.getSuperclass();
+		}
+		throw new IllegalArgumentException(e);
+	}
+
+	public static enum Modifier {
+
+		PUBLIC, PRIVATE, PROTECTED, STATIC, FINAL, SYNCHRONIZED, VOLATILE, TRANSIENT, NATIVE, INTERFACE, ABSTRACT, STRICT, BRIDGE, VARARGS, SYNTHETIC, ANNOTATION, ENUM, MANDATED;
+
+		final int modifier;
+
+		private Modifier(){
+			modifier = new AClass<java.lang.reflect.Modifier>(java.lang.reflect.Modifier.class).<Integer> getDeclaredField(this.name()).setAccessible(true).get(null);
+		}
+
+		private boolean is(int original){
+			return (original & modifier) != 0;
+		}
+
+		private int set(int original, boolean on){
+			if(on){
+				return original | modifier;
+			} else{
+				return original & (~modifier);
+			}
+		}
+
+	}
+
+	public static class AClass<C> {
+
+		protected final Class<C> clas;
+
+		public AClass(Class<C> clas){
+			this.clas = clas;
+		}
+
+		public AClass(String clas){
+			try{
+				this.clas = (Class<C>) Class.forName(clas);
+			} catch(Exception e){
+				throw new RuntimeException(e);
+			}
+		}
+
+		public Class<C> get(){
+			return clas;
+		}
+
+		public Optional<AClass<? super C>> getSuperclass(){
+			return clas.getSuperclass() != null ? Optional.of(new AClass<>(clas.getSuperclass())) : Optional.empty();
+		}
+
+		public boolean isInterface(){
+			return clas.isInterface();
+		}
+
+		public AInterface<C> asInterface(){
+			return new AInterface<>(clas);
+		}
+
+		public boolean isEnum(){
+			return clas.isEnum();
+		}
+
+		public <E extends Enum<E>> AEnum<E> asEnum(){
+			return new AEnum<E>((Class<E>) clas);
+		}
+
+		public boolean isAnnotation(){
+			return clas.isAnnotation();
+		}
+
+		public AAnnotation<C> asAnnotation(){
+			return new AAnnotation<>(clas);
+		}
+
+		public AConstructor<C> getDeclaredConstructor(Class<?>... args){
+			try{
+				return new AConstructor<C>(this, clas.getDeclaredConstructor(args));
+			} catch(ReflectiveOperationException e){
+				throw new RuntimeException(e);
+			}
+		}
+
+		public List<AConstructor<C>> getDeclaredConstructors(){
+			return Lists.transform(Arrays.asList(clas.getDeclaredConstructors()), constructor -> new AConstructor<>(this, (Constructor<C>) constructor));
+		}
+
+		public <T> AField<C, T> getDeclaredField(String... names){
+			return new AField<C, T>(this, findField(clas, names));
+		}
+
+		public List<AField<C, ?>> getDeclaredFields(){
+			return Lists.transform(Arrays.asList(clas.getDeclaredFields()), field -> new AField<>(this, field));
+		}
+
+		public List<AField<? super C, ?>> getFields(){
+			List sup = new ArrayList<>();
+			getSuperclass().ifPresent(clas -> sup.addAll(clas.getFields()));
+			sup.addAll(getDeclaredFields());
+			return sup;
+		}
+
+		public <T> AMethod<C, T> getDeclaredMethod(String[] names, Class<?>... args){
+			return new AMethod<C, T>(this, findMethod(clas, names, args));
+		}
+
+		public List<AMethod<C, ?>> getDeclaredMethods(){
+			return Lists.transform(Arrays.asList(clas.getDeclaredMethods()), method -> new AMethod<>(this, method));
+		}
+
+		public List<AMethod<? super C, ?>> getMethods(){
+			List sup = new ArrayList<>();
+			getSuperclass().ifPresent(clas -> sup.addAll(clas.getMethods()));
+			sup.addAll(getDeclaredMethods());
+			return sup;
+		}
+
+		public static class AInterface<C> extends AClass<C> {
+
+			private AInterface(Class<C> clas){
+				super(clas);
+			}
+
+			public C proxy(InvocationHandler handler, AInterface<?>... interfaces){
+				return proxy(clas.getClassLoader(), handler, interfaces);
+			}
+
+			public C proxy(ClassLoader loader, InvocationHandler handler, AInterface<?>... interfaces){
+				return (C) Proxy.newProxyInstance(loader, Arrays.stream(ArrayUtils.add(interfaces, 0, this)).map(iface -> iface.clas).collect(Collectors.toList()).toArray(new Class<?>[0]), handler);
+			}
+
+		}
+
+		public static class AEnum<C extends Enum<C>> extends AClass<C> {
+
+			private static final AClass<?> reflectionFactory = new AClass<>("sun.reflect.ReflectionFactory");
+			private static final AMethod getReflectionFactory = reflectionFactory.getDeclaredMethod(new String[]{"getReflectionFactory"}).setAccessible(true);
+			private static final AMethod newConstructorAccessor = reflectionFactory.getDeclaredMethod(new String[]{"newConstructorAccessor"}, Constructor.class).setAccessible(true);
+			private static final AClass<?> constructorAccessor = new AClass<>("sun.reflect.ConstructorAccessor");
+			private static final AMethod newInstance = constructorAccessor.getDeclaredMethod(new String[]{"newInstance"}, Object[].class).setAccessible(true);
+
+			private final AField<C, C[]> VALUES;
+			private final Object factory;
+
+			private AEnum(Class<C> clas){
+				super(clas);
+				VALUES = getDeclaredField("$VALUES", "ENUM$VALUES");
+				VALUES.setAccessible(true).setFinal(false);
+				factory = getReflectionFactory.invoke(null);
+			}
+
+			public C[] enums(){
+				return clas.getEnumConstants();
+			}
+
+			public C getEnum(int ordinal){
+				return enums()[ordinal];
+			}
+
+			public C getEnum(String name){
+				return Enum.valueOf(clas, name);
+			}
+
+			public C createEnum(String name, Object... params){
+				params = ArrayUtils.addAll(new Object[]{name, enums().length}, params);
+				Class[] paramc = Arrays.stream(params).map(param -> param.getClass()).collect(Collectors.toList()).toArray(new Class[0]);
+				paramc[1] = int.class;
+				return (C) newInstance.invoke(newConstructorAccessor.invoke(factory, getDeclaredConstructor(paramc).get()), (Object) params);
+			}
+
+			public C addEnum(String name, Object... params){
+				C c = createEnum(name, params);
+				VALUES.set(null, ArrayUtils.add(clas.getEnumConstants(), c));
+				return c;
+			}
+
+			public void removeEnum(C c){
+				VALUES.set(null, ArrayUtils.removeElement(enums(), c));
+			}
+
+		}
+
+		public static class AAnnotation<C> extends AClass<C> {
+
+			private AAnnotation(Class<C> clas){
+				super(clas);
+			}
+
+		}
+
+	}
+
+	private static abstract class ReflectionObject<C, T, R extends ReflectionObject<C, T, R>> {
+
+		private final AClass<C> clas;
+		private final T t;
+
+		private ReflectionObject(AClass<C> clas, T t){
+			this.clas = clas;
+			this.t = t;
+		}
+
+		public AClass<C> clas(){
+			return clas;
+		}
+
+		public final T get(){
+			return t;
+		}
+
+		public List<Modifier> modifiers(){
+			return Lists.newArrayList(Modifier.values()).stream().filter(modifier -> is(modifier)).collect(Collectors.toList());
+		}
+
+		public abstract boolean is(Modifier modifier);
+
+		public abstract R set(Modifier modifier, boolean on);
+
+	}
+
+	private static interface IAccessibleReflectionObject<C, T, R extends ReflectionObject<C, T, R> & IAccessibleReflectionObject<C, T, R>> {
+
+		public abstract boolean isAccessible();
+
+		public abstract R setAccessible(boolean accessible);
+
+	}
+
+	private static abstract class AccessibleReflectionObject<C, T extends AccessibleObject, R extends AccessibleReflectionObject<C, T, R>> extends ReflectionObject<C, T, R> implements IAccessibleReflectionObject<C, T, R> {
+
+		private AccessibleReflectionObject(AClass<C> clas, T t){
+			super(clas, t);
+		}
+
+		@Override
+		public boolean isAccessible(){
+			return get().isAccessible();
+		}
+
+		@Override
+		public R setAccessible(boolean accessible){
+			get().setAccessible(accessible);
+			return (R) this;
+		}
+
+	}
+
+	public static class AConstructor<C> extends AccessibleReflectionObject<C, Constructor<C>, AConstructor<C>> {
+
+		private AConstructor(AClass<C> clas, Constructor<C> constructor){
+			super(clas, constructor);
+		}
+
+		@Override
+		public boolean is(Modifier modifier){
+			return modifier.is(get().getModifiers());
+		}
+
+		@Override
+		public AConstructor<C> set(Modifier modifier, boolean on){
+			try{
+				fieldConstructorModifiers.setInt(get(), modifier.set(get().getModifiers(), on));
+			} catch(Exception e){
+				throw new RuntimeException(e);
+			}
+			return this;
+		}
+
+		public C newInstance(Object... args){
+			try{
+				return get().newInstance(args);
+			} catch(Exception e){
+				throw new RuntimeException(e);
+			}
+		}
+
+	}
+
+	public static class AField<C, T> extends AccessibleReflectionObject<C, Field, AField<C, T>> {
+
+		private AField(AClass<C> clas, Field field){
+			super(clas, field);
+		}
+
+		@Override
+		public boolean is(Modifier modifier){
+			return modifier.is(get().getModifiers());
+		}
+
+		@Override
+		public AField<C, T> set(Modifier modifier, boolean on){
+			try{
+				fieldFieldModifiers.setInt(get(), modifier.set(get().getModifiers(), on));
+			} catch(Exception e){
+				throw new RuntimeException(e);
+			}
+			return this;
+		}
+
+		public AField<C, T> setFinal(boolean finall){
+			return set(Modifier.FINAL, finall);
+		}
+
+		public <I extends C> T get(I instance){
+			try{
+				return (T) get().get(instance);
+			} catch(Exception e){
+				throw new RuntimeException(e);
+			}
+		}
+
+		public <I extends C> void set(I instance, Object t){
+			try{
+				get().set(instance, t);
+			} catch(Exception e){
+				throw new RuntimeException(e);
+			}
+		}
+
+	}
+
+	public static class AMethod<C, T> extends AccessibleReflectionObject<C, Method, AMethod<C, T>> {
+
+		private AMethod(AClass<C> clas, Method method){
+			super(clas, method);
+		}
+
+		@Override
+		public boolean is(Modifier modifier){
+			return modifier.is(get().getModifiers());
+		}
+
+		@Override
+		public AMethod<C, T> set(Modifier modifier, boolean on){
+			try{
+				fieldMethodModifiers.setInt(get(), modifier.set(get().getModifiers(), on));
+			} catch(Exception e){
+				throw new RuntimeException(e);
+			}
+			return this;
+		}
+
+		public <I extends C> T invoke(I instance, Object... args){
+			try{
+				return (T) get().invoke(instance, args);
+			} catch(Exception e){
+				throw new RuntimeException(e);
+			}
+		}
+
+	}
+
+}


### PR DESCRIPTION
De-ASM-ified RenderManager#doRenderEntity using reflection load time replacement with override class intercepting methods we were patching with ASM.
Comes with minor performance improvements (indirectly reduces number of GL calls).
![Piggies!](http://i.imgur.com/7u1ZyfT.png)