### PR TITLE
BigBastardPhony Changes

### DIFF
--- a/src/main/java/ValkyrienWarfareBase/ChunkManagement/DimensionPhysicsChunkManager.java
+++ b/src/main/java/ValkyrienWarfareBase/ChunkManagement/DimensionPhysicsChunkManager.java
@@ -20,15 +20,6 @@ public class DimensionPhysicsChunkManager {
 		}
 	}
 
-	public boolean isChunkInShipRange(World world, int x, int z) {
-		PhysicsChunkManager manager = getManagerForWorld(world);
-		if (manager != null) {
-			return manager.isChunkInShipRange(x, z, world.isRemote);
-		} else {
-			return false;
-		}
-	}
-
 	public PhysicsChunkManager getManagerForWorld(World world) {
 		if(world == null){
 			return null;

--- a/src/main/java/ValkyrienWarfareBase/ChunkManagement/PhysicsChunkManager.java
+++ b/src/main/java/ValkyrienWarfareBase/ChunkManagement/PhysicsChunkManager.java
@@ -56,11 +56,4 @@ public class PhysicsChunkManager {
 		nextChunkSetKey = data.chunkKey;
 	}
 
-	// Warning: This may end up becoming an issue in future, possibly move this to a variable in the Chunk class
-	public boolean isChunkInShipRange(int x, int z, boolean isClient) {
-		boolean xInRange = x >= (xChunkStartingPos - maxChunkRadius * 2);
-		boolean zInRange = z >= (zChunkStartingPos - maxChunkRadius * 2);
-		return xInRange && zInRange;
-	}
-
 }

--- a/src/main/java/ValkyrienWarfareBase/Command/AirshipSettingsCommand.java
+++ b/src/main/java/ValkyrienWarfareBase/Command/AirshipSettingsCommand.java
@@ -39,7 +39,7 @@ public static final ArrayList<String> completionOptions = new ArrayList<String>(
 
 	@Override
 	public String getCommandUsage(ICommandSender sender) {
-		return "/airshipSettings <setting name> [value]";
+		return "/airshipSettings <setting name> [value]" + "\n" + "Avaliable Settings: [transfer, allowPlayer, claim]";
 	}
 
 	@Override

--- a/src/main/java/ValkyrienWarfareBase/CoreMod/CallRunner.java
+++ b/src/main/java/ValkyrienWarfareBase/CoreMod/CallRunner.java
@@ -499,7 +499,7 @@ public class CallRunner {
 	}
 
 	public static void onChunkUnload(ChunkProviderServer provider, Chunk chunk) {
-		if (!ValkyrienWarfareMod.chunkManager.isChunkInShipRange(provider.worldObj, chunk.xPosition, chunk.zPosition)) {
+//		if (!ValkyrienWarfareMod.chunkManager.isChunkInShipRange(provider.worldObj, chunk.xPosition, chunk.zPosition)) {
 			if (!chunk.worldObj.isSpawnChunk(chunk.xPosition, chunk.zPosition)) {
 				for (int i = 0; i < chunk.entityLists.length; ++i) {
 					Collection<Entity> c = chunk.entityLists[i];
@@ -511,7 +511,7 @@ public class CallRunner {
 				}
 			}
 			provider.unload(chunk);
-		}
+//		}
 	}
 	
     public static Vec3d onGetLook(Entity entityFor, float partialTicks){

--- a/src/main/java/ValkyrienWarfareBase/EventsCommon.java
+++ b/src/main/java/ValkyrienWarfareBase/EventsCommon.java
@@ -25,11 +25,11 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
@@ -44,6 +44,7 @@ import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.BlockEvent.BreakEvent;
 import net.minecraftforge.event.world.BlockEvent.HarvestDropsEvent;
 import net.minecraftforge.event.world.ChunkDataEvent;
+import net.minecraftforge.event.world.ChunkEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.eventhandler.Event.Result;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
@@ -59,6 +60,11 @@ public class EventsCommon {
 
 	public static HashMap<EntityPlayerMP, Double[]> lastPositions = new HashMap<EntityPlayerMP, Double[]>();
 
+	@SubscribeEvent(priority = EventPriority.HIGHEST)
+	public void onUnloadChunk(ChunkEvent.Unload event){
+
+	}
+	
 	//TODO: Use this to fix the issue with mounted entities on Ships
 	@SubscribeEvent(priority = EventPriority.HIGHEST)
 	public void onEnterChunkEvent(EnteringChunk event) {
@@ -449,7 +455,7 @@ public class EventsCommon {
 		if (!event.getWorld().isRemote)	{
 			PhysicsWrapperEntity physObj = ValkyrienWarfareMod.physicsManager.getObjectManagingPos(event.getWorld(), event.getPos());
 			if (physObj != null)	{
-				if (!(physObj.wrapping.creator.equals(event.getEntityPlayer().entityUniqueID.toString()) || physObj.wrapping.allowedUsers.contains(event.getEntityPlayer().entityUniqueID.toString())))	{
+				if (ValkyrienWarfareMod.runAirshipPermissions && !(physObj.wrapping.creator.equals(event.getEntityPlayer().entityUniqueID.toString()) || physObj.wrapping.allowedUsers.contains(event.getEntityPlayer().entityUniqueID.toString())))	{
 					event.getEntityPlayer().addChatMessage(new TextComponentString("You need to be added to the airship to do that!" + (physObj.wrapping.creator == null || physObj.wrapping.creator.trim().isEmpty() ? " Try using \"/airshipSettings claim\"!" : "")));
 					event.setCanceled(true);
 					return;
@@ -463,7 +469,7 @@ public class EventsCommon {
 		if (!event.getWorld().isRemote)	{
 			PhysicsWrapperEntity physObj = ValkyrienWarfareMod.physicsManager.getObjectManagingPos(event.getWorld(), event.getPos());
 			if (physObj != null)	{
-				if (!(physObj.wrapping.creator.equals(event.getPlayer().entityUniqueID.toString()) || physObj.wrapping.allowedUsers.contains(event.getPlayer().entityUniqueID.toString())))	{
+				if (ValkyrienWarfareMod.runAirshipPermissions && !(physObj.wrapping.creator.equals(event.getPlayer().entityUniqueID.toString()) || physObj.wrapping.allowedUsers.contains(event.getPlayer().entityUniqueID.toString())))	{
 					event.getPlayer().addChatMessage(new TextComponentString("You need to be added to the airship to do that!" + (physObj.wrapping.creator == null || physObj.wrapping.creator.trim().isEmpty() ? " Try using \"/airshipSettings claim\"!" : "")));
 					event.setCanceled(true);
 					return;

--- a/src/main/java/ValkyrienWarfareBase/PhysicsManagement/DimensionPhysObjectManager.java
+++ b/src/main/java/ValkyrienWarfareBase/PhysicsManagement/DimensionPhysObjectManager.java
@@ -72,14 +72,11 @@ public class DimensionPhysObjectManager {
 		if (chunk == null) {
 			return null;
 		}
-		if (ValkyrienWarfareMod.chunkManager.isChunkInShipRange(chunk.worldObj, chunk.xPosition, chunk.zPosition)) {
-			WorldPhysObjectManager physManager = getManagerForWorld(chunk.worldObj);
-			if (physManager == null) {
-				return null;
-			}
-			return physManager.getManagingObjectForChunk(chunk);
+		WorldPhysObjectManager physManager = getManagerForWorld(chunk.worldObj);
+		if (physManager == null) {
+			return null;
 		}
-		return null;
+		return physManager.getManagingObjectForChunk(chunk);
 	}
 
 	public PhysicsWrapperEntity getObjectManagingPos(World world, BlockPos pos) {

--- a/src/main/java/ValkyrienWarfareBase/PhysicsManagement/PhysicsObject.java
+++ b/src/main/java/ValkyrienWarfareBase/PhysicsManagement/PhysicsObject.java
@@ -139,7 +139,6 @@ public class PhysicsObject {
 	}
 
 	public void onSetBlockState(IBlockState oldState, IBlockState newState, BlockPos posAt) {
-
 		boolean isOldAir = oldState == null || oldState.getBlock().equals(Blocks.AIR);
 		boolean isNewAir = newState == null || newState.getBlock().equals(Blocks.AIR);
 
@@ -187,7 +186,6 @@ public class PhysicsObject {
 							e.printStackTrace();
 						}
 					}
-
 					ValkyrienWarfareMod.chunkManager.getManagerForWorld(worldObj).data.avalibleChunkKeys.add(ownedChunks.centerX);
 				}
 			}
@@ -205,7 +203,6 @@ public class PhysicsObject {
 	}
 
 	public void destroy() {
-
 		wrapper.setDead();
 		ArrayList<EntityPlayerMP> watchersCopy = (ArrayList<EntityPlayerMP>) watchingPlayers.clone();
 		for (EntityPlayerMP wachingPlayer : watchersCopy) {

--- a/src/main/java/ValkyrienWarfareBase/PhysicsManagement/PhysicsTickHandler.java
+++ b/src/main/java/ValkyrienWarfareBase/PhysicsManagement/PhysicsTickHandler.java
@@ -13,6 +13,10 @@ public class PhysicsTickHandler {
 	public static void onWorldTickStart(World world) {
 		WorldPhysObjectManager manager = ValkyrienWarfareMod.physicsManager.getManagerForWorld(world);
 
+		if(!world.isRemote && world.provider.isSurfaceWorld()){
+//			System.out.println(manager.physicsEntities.size());
+		}
+		
 		ArrayList<PhysicsWrapperEntity> toUnload = (ArrayList<PhysicsWrapperEntity>) manager.physicsEntitiesToUnload.clone();
 		manager.physicsEntitiesToUnload.clear();
 

--- a/src/main/java/ValkyrienWarfareBase/ValkyrienWarfareMod.java
+++ b/src/main/java/ValkyrienWarfareBase/ValkyrienWarfareMod.java
@@ -98,6 +98,8 @@ public class ValkyrienWarfareMod {
 	public static int maxAirships = -1;
 	public static boolean highAccuracyCollisions = false;
 	public static boolean accurateRain = false;
+	
+	public static boolean runAirshipPermissions = false;
 
 	// NOTE: These only calculate physics, so they are only relevant to the Server end
 	public static ExecutorService MultiThreadExecutor;
@@ -191,6 +193,8 @@ public class ValkyrienWarfareMod {
 		highAccuracyCollisions = config.get(Configuration.CATEGORY_GENERAL, "Enables higher collision accuracy", false, "Debug feature, takes an insane amount of processing power").getBoolean();
 		
 		accurateRain = config.get(Configuration.CATEGORY_GENERAL, "Enables accurate rain on ships", false, "Debug feature, takes a lot of processing power").getBoolean();
+		
+		runAirshipPermissions = config.get(Configuration.CATEGORY_GENERAL, "Enables the airship permissions system", false, "Enables the airship permissions system").getBoolean();
 		
 		if (MultiThreadExecutor != null) {
 			MultiThreadExecutor.shutdown();


### PR DESCRIPTION
Adds Entity angular velocity persistance to the existing linear velocity peristance.

Disables ship permissions by default, adds a config option for servers to enable them.

Prep for reworking the way PhysicsWrapperEntities get unloaded by the world; it seems that Minecraft has simply been keeping every single PhysicsObject loaded regardless of where the players were.