### PR TITLE
Fixes #134 (Creative tab compatibility)

### DIFF
--- a/src/main/java/valkyrienwarfare/mod/gui/TabValkyrienWarfare.java
+++ b/src/main/java/valkyrienwarfare/mod/gui/TabValkyrienWarfare.java
@@ -24,7 +24,7 @@ import valkyrienwarfare.ValkyrienWarfareMod;
 public class TabValkyrienWarfare extends CreativeTabs {
 
     public TabValkyrienWarfare() {
-        super(12, "valkyrienwarfare");
+        super("valkyrienwarfare");
     }
 
     @Override


### PR DESCRIPTION
 Removed the arbitrary creative tab index from TabValkyrienWarfare so that it no longer overwrites other mods' creative tabs.